### PR TITLE
Fix adding 'username' column in migrations

### DIFF
--- a/database/migrations/2020_11_17_071936_create_users_table.php
+++ b/database/migrations/2020_11_17_071936_create_users_table.php
@@ -19,7 +19,6 @@ class CreateUsersTable extends Migration
             $table->string('email')->unique();
             $table->text('password');
             $table->text('last_issued_token')->nullable();
-            $table->string('username')->nullable();
 
             $table->timestamps();
         });


### PR DESCRIPTION
Having this column definition in both the 'create_users_table' and 'add_username_to_users_table'﻿ does collide when runing a fresh migration.
